### PR TITLE
Add no_check_rule function

### DIFF
--- a/lib/Smart/Args/TypeTiny.pm
+++ b/lib/Smart/Args/TypeTiny.pm
@@ -322,7 +322,7 @@ For optimization calling subroutine in runtime type check, you can overwrite C<c
         *Smart::Args::TypeTiny::check_rule = \&Smart::Args::TypeTiny::Check::no_check_rule;
     }
 
-C<Smart::Args::TypeTiny::Check::no_check_rule> is a function without type checking, but settings such as default and optional work the same as C<check_rule>.
+C<Smart::Args::TypeTiny::Check::no_check_rule> is a function without type checking and type coerce, but settings such as default and optional work the same as C<check_rule>.
 
 =head1 SEE ALSO
 

--- a/lib/Smart/Args/TypeTiny.pm
+++ b/lib/Smart/Args/TypeTiny.pm
@@ -319,11 +319,10 @@ For optimization calling subroutine in runtime type check, you can overwrite C<c
 
     {
         no warnings 'redefine';
-        sub Smart::Args::TypeTiny::check_rule {
-            my ($rule, $value, $exists, $name) = @_;
-            return $value;
-        }
+        *Smart::Args::TypeTiny::check_rule = \&Smart::Args::TypeTiny::Check::no_check_rule;
     }
+
+C<Smart::Args::TypeTiny::Check::no_check_rule> is a function without type checking, but settings such as default and optional work the same as C<check_rule>.
 
 =head1 SEE ALSO
 

--- a/t/13_check.t
+++ b/t/13_check.t
@@ -1,5 +1,5 @@
 use Test2::V0;
-use Smart::Args::TypeTiny::Check qw/check_rule check_type type type_role/;
+use Smart::Args::TypeTiny::Check qw/check_rule no_check_rule check_type type type_role/;
 use Types::Standard -all;
 
 sub type_name {
@@ -9,18 +9,124 @@ sub type_name {
     };
 }
 
-subtest 'check_rule' => sub {
-    is check_rule({isa => Int}, 1, 1), 1;
-    is check_rule({isa => Int, default => 99},        undef, 0), 99;
-    is check_rule({isa => Int, default => sub { 1 }}, undef, 0), 1;
-    is check_rule({isa => Int, optional => 1},        undef, 0), undef;
-    is check_rule({isa => Int, optional => 1},        undef, 1), undef;
-    like dies { check_rule({isa => Int}, undef, 0, 'foo') },
-        qr/Required parameter 'foo' not passed/;
-    like dies { check_rule({isa => Int}, undef, 1, 'foo') },
-        qr/Type check failed in binding to parameter '\$foo'; Undef did not pass type constraint "Int"/;
-    like dies { check_rule({optioanl => 'Foo'}, undef, 0, 'foo') },
-        qr/Malformed rule for 'foo' \(isa, does, optional, default\)/;
+{
+    # common test cases for check_rule and no_check_rule
+    my @tests = (
+        {
+            test     => 'When a rule is not hashref',
+            args     => [Int, 123, 1, 'foo'],
+            expected => 123,
+        },
+        {
+            test     => 'When a rule is hashref',
+            args     => [{isa => Int}, 123, 1, 'foo'],
+            expected => 123,
+        },
+        {
+            test     => 'Not given a value but has default, return the default',
+            args     => [{isa => Int, default => 99}, undef, 0, 'foo'],
+            expected => 99,
+        },
+        {
+            test     => 'Not given a value but has default coderef, return the result of default coderef',
+            args     => [{isa => Int, default => sub { 123 }}, undef, 0, 'foo'],
+            expected => 123,
+        },
+        {
+            test     => 'Not given a value but optional, return undef',
+            args     => [{isa => Int, optional => 1}, undef, 0, 'foo'],
+            expected => undef,
+        },
+        {
+            test     => 'Given a undefined value and optional, return undef',
+            args     => [{isa => Int, optional => 1}, undef, 1, 'foo'],
+            expected => undef,
+        },
+        {
+            test     => 'Not given a value but not optional, throw an exception',
+            args     => [{isa => Int}, undef, 0, 'foo'],
+            throw    => qr/Required parameter 'foo' not passed/,
+        },
+        {
+            test => 'Malformed rule',
+            args => [{optioanl => 'Foo'}, undef, 0, 'foo'],
+            throw => qr/Malformed rule for 'foo' \(isa, does, optional, default\)/,
+        },
+    );
+
+    my @type_tests = (
+        {
+            test     => '123 is Int',
+            args     => [Int, 123, 1, 'foo'],
+            expected => 123,
+        },
+        {
+            test     => '"Hello" is not Int',
+            args     => [Int, 'Hello', 1, 'foo'],
+            throw    => qr/Type check failed in binding to parameter '\$foo'; Value "Hello" did not pass type constraint "Int"/,
+        },
+        {
+            test     => 'Undef is not Int',
+            args     => [Int, undef, 1, 'foo'],
+            throw    => qr/Type check failed in binding to parameter '\$foo'; Undef did not pass type constraint "Int"/,
+        },
+        {
+            test     => '123 is not AraayRef',
+            args     => [ArrayRef, 123, 1, 'foo'],
+            throw    => qr/Type check failed in binding to parameter '\$foo'; Value "123" did not pass type constraint "ArrayRef"/,
+        },
+        {
+            test     => 'ArrayRef with coercion',
+            args     => [ArrayRef->plus_coercions(Int, q{[$_]}), 123, 1, 'foo'],
+            expected => [123],
+        },
+    );
+
+    subtest 'check_rule' => sub {
+        for (@tests) {
+            my ($test, $args, $expected, $throw) = @{$_}{qw/test args expected throw/};
+            my ($rule, $value, $exists, $name) = @$args;
+
+            if ($throw) {
+                like dies { check_rule($rule, $value, $exists, $name) }, $throw, $test;
+            } else {
+                is check_rule($rule, $value, $exists, $name), $expected, $test;
+            }
+        }
+
+        subtest 'Throw an exception if the type check fails' => sub {
+            for (@type_tests) {
+                my ($test, $args, $expected, $throw) = @{$_}{qw/test args expected throw/};
+                my ($rule, $value, $exists, $name) = @$args;
+                if ($throw) {
+                    like dies { check_rule($rule, $value, $exists, $name) }, $throw, $test;
+                } else {
+                    is check_rule($rule, $value, $exists, $name), $expected, $test;
+                }
+            }
+        }
+    };
+
+    subtest 'no_check_rule' => sub {
+        for (@tests) {
+            my ($test, $args, $expected, $throw) = @{$_}{qw/test args expected throw/};
+            my ($rule, $value, $exists, $name) = @$args;
+
+            if ($throw) {
+                like dies { no_check_rule($rule, $value, $exists, $name) }, $throw, $test;
+            } else {
+                is no_check_rule($rule, $value, $exists, $name), $expected, $test;
+            }
+        }
+
+        subtest '*Not* throw an exception if the type check fails' => sub {
+            for (@type_tests) {
+                my ($test, $args) = @{$_}{qw/test args/};
+                my ($rule, $value, $exists, $name) = @$args;
+                ok lives { no_check_rule($rule, $value, $exists, $name) }, $test;
+            }
+        }
+    };
 };
 
 subtest 'check_type' => sub {

--- a/t/13_check.t
+++ b/t/13_check.t
@@ -79,6 +79,7 @@ sub type_name {
             test     => 'ArrayRef with coercion',
             args     => [ArrayRef->plus_coercions(Int, q{[$_]}), 123, 1, 'foo'],
             expected => [123],
+            no_check_rule_expected => 123, # no_check_rule does not coerce value
         },
     );
 
@@ -121,9 +122,16 @@ sub type_name {
 
         subtest '*Not* throw an exception if the type check fails' => sub {
             for (@type_tests) {
-                my ($test, $args) = @{$_}{qw/test args/};
+                my ($test, $args, $expected, $throw, $no_check_rule_expected) = @{$_}{qw/test args expected throw no_check_rule_expected/};
                 my ($rule, $value, $exists, $name) = @$args;
-                ok lives { no_check_rule($rule, $value, $exists, $name) }, $test;
+                if ($throw) {
+                    # not dies
+                    ok lives { no_check_rule($rule, $value, $exists, $name) }, $test;
+                } elsif (defined $no_check_rule_expected) {
+                    is no_check_rule($rule, $value, $exists, $name), $no_check_rule_expected, $test . ' (no_check_rule)';
+                } else {
+                    is no_check_rule($rule, $value, $exists, $name), $expected, $test;
+                }
             }
         }
     };

--- a/t/14_nocheck.t
+++ b/t/14_nocheck.t
@@ -4,19 +4,37 @@ use Smart::Args::TypeTiny;
 
 {
     no warnings 'redefine';
-    sub Smart::Args::TypeTiny::check_rule {
-        my ($rule, $value, $exists, $name) = @_;
-        return $value;
-    }
+    *Smart::Args::TypeTiny::check_rule = \&Smart::Args::TypeTiny::Check::no_check_rule;
 }
 
 sub foo {
-    Smart::Args::TypeTiny::args(my $x => Int);
+    args my $x => Int;
+    return $x;
+}
+
+sub bar {
+    args my $x => { isa => Str, default => 'bar!' };
+    return $x;
+}
+
+sub baz {
+    args my $x => { isa => Int, optional => 1 };
     return $x;
 }
 
 is foo(x => 1), 1;
 is foo(x => 'A'), 'A';
 is foo(x => []), [];
+like dies { foo() }, qr/Required parameter 'x' not passed/, 'Required parameter not passed';
+
+is bar(x => 1), 1;
+is bar(x => 'A'), 'A';
+is bar(x => []), [];
+is bar(), 'bar!', 'Default value';
+
+is baz(x => 1), 1;
+is baz(x => 'A'), 'A';
+is baz(x => []), [];
+is baz(), undef, 'Optional parameter not passed';
 
 done_testing;


### PR DESCRIPTION
This pull request provides `no_check_rule` function. This is without type checking and type coerce, but settings such as default and optional work the same as `check_rule`.